### PR TITLE
Attempt to address issues with path_info encoding in Python3

### DIFF
--- a/wsgi_intercept/__init__.py
+++ b/wsgi_intercept/__init__.py
@@ -107,7 +107,7 @@ except ImportError:
     from StringIO import StringIO as BytesIO
 
 try:
-    from urllib.parse import unquote as url_unquote
+    from urllib.parse import unquote_to_bytes as url_unquote
 except ImportError:
     from urllib import unquote as url_unquote
 
@@ -249,6 +249,14 @@ def make_environ(inp, host, port, script_name):
     #
     # fill out our dictionary.
     #
+
+    # In Python3 turn the bytes of the path info into a string of
+    # latin-1 code points, because that's what the spec says we must
+    # do to be like a server. Later various libraries will be forced
+    # to decode and then reencode to get the UTF-8 that everyone
+    # wants.
+    if sys.version_info[0] > 2:
+        path_info = path_info.decode('latin-1')
 
     environ.update({
         "wsgi.version": (1, 0),


### PR DESCRIPTION
A server should present PATH_INFO as a string that only contains
codepoints from latin-1. This means that if you have a URL that was
UTF-8 encoded and then urlquoted there is quite a dance to get it
through the system. This attempts to get it right.