### PR TITLE
process headers only when application is processed

### DIFF
--- a/test/test_wsgi_compliance.py
+++ b/test/test_wsgi_compliance.py
@@ -85,3 +85,12 @@ def test_encoding_errors():
             response, content = http.request(
                 'http://some_hopefully_nonexistant_domain/boom/baz',
                 headers={'Accept': u'application/\u2603'})
+
+
+def test_post_status_headers():
+    with InstalledApp(wsgi_app.post_status_headers_app, host=HOST) as app:
+        http = httplib2.Http()
+        resp, content = http.request(
+            'http://some_hopefully_nonexistant_domain/', 'GET')
+        assert app.success()
+        assert resp.get('content-type') == 'text/plain'

--- a/test/wsgi_app.py
+++ b/test/wsgi_app.py
@@ -23,5 +23,12 @@ def more_interesting_app(environ, start_response):
     return [pformat(environ).encode('utf-8')]
 
 
+def post_status_headers_app(environ, start_response):
+    headers = []
+    start_response('200 OK', headers)
+    headers.append(('Content-type', 'text/plain'))
+    return [b'WSGI intercept successful!\n']
+
+
 def raises_app(environ, start_response):
     raise TypeError("bah")


### PR DESCRIPTION
An application can modify the headers after
start_response have been processed.

So we have to store the references of the headers list.

And write them to the client only when the application
have been processed but before we iter the body.

wsgiref and weboob already does the same thing.